### PR TITLE
Use dynamic block to set the runner chart configuration

### DIFF
--- a/actions-arc-dind-chart/main.tf
+++ b/actions-arc-dind-chart/main.tf
@@ -17,29 +17,12 @@ resource "helm_release" "actions_arc_runner" {
   chart      = "gha-runner-scale-set"
   version    = var.arc_runner_chart_version
 
-  set {
-    name  = "githubConfigUrl"
-    value = var.githubConfigUrl
-  }
-
-  set {
-    name  = "githubConfigSecret.github_token"
-    value = var.github_token
-  }
-
-  set {
-    name  = "maxRunners"
-    value = var.maxRunners
-  }
-
-  set {
-    name  = "minRunners"
-    value = var.minRunners
-  }
-
-  set {
-    name  = "containerMode.type"
-    value = var.containerModeType
+  dynamic "set" {
+    for_each = var.arc_runner_config
+    content {
+      name  = set.value["name"]
+      value = set.value["value"]
+    }
   }
 
   depends_on = [helm_release.actions_arc_controller]

--- a/actions-arc-dind-chart/variables.tf
+++ b/actions-arc-dind-chart/variables.tf
@@ -1,26 +1,14 @@
-variable "arc_controller_namespace" {
-}
+variable "arc_controller_namespace" {}
 
-variable "arc_controller_chart_version" {
-}
+variable "arc_controller_chart_version" {}
 
-variable "arc_runner_namespace" {
-}
+variable "arc_runner_namespace" {}
 
-variable "arc_runner_chart_version" {
-}
+variable "arc_runner_chart_version" {}
 
-variable "githubConfigUrl" {
-}
-
-variable "github_token" {
-}
-
-variable "maxRunners" {
-}
-
-variable "minRunners" {
-}
-
-variable "containerModeType" {
+variable "arc_runner_config" {
+  type = list(object({
+    name  = string
+    value = string
+  }))
 }

--- a/actions-arc-k8s-chart/main.tf
+++ b/actions-arc-k8s-chart/main.tf
@@ -17,44 +17,12 @@ resource "helm_release" "actions_arc_runner" {
   chart      = "gha-runner-scale-set"
   version    = var.arc_runner_chart_version
 
-  set {
-    name  = "githubConfigUrl"
-    value = var.githubConfigUrl
-  }
-
-  set {
-    name  = "githubConfigSecret.github_token"
-    value = var.github_token
-  }
-
-  set {
-    name  = "maxRunners"
-    value = var.maxRunners
-  }
-
-  set {
-    name  = "minRunners"
-    value = var.minRunners
-  }
-
-  set {
-    name  = "containerMode.type"
-    value = var.containerModeType
-  }
-
-  set {
-    name  = "containerMode.kubernetesModeWorkVolumeClaim.accessModes[0]"
-    value = var.VolumeClaimAccessModes
-  }
-
-  set {
-    name  = "containerMode.kubernetesModeWorkVolumeClaim.storageClassName"
-    value = var.VolumeClaimStorageClassName
-  }
-
-  set {
-    name  = "containerMode.kubernetesModeWorkVolumeClaim.resources.requests.storage"
-    value = var.VolumeClaimResourcesRequestsStorage
+  dynamic "set" {
+    for_each = var.arc_runner_config
+    content {
+      name  = set.value["name"]
+      value = set.value["value"]
+    }
   }
 
   depends_on = [helm_release.actions_arc_controller]

--- a/actions-arc-k8s-chart/variables.tf
+++ b/actions-arc-k8s-chart/variables.tf
@@ -1,35 +1,14 @@
-variable "arc_controller_namespace" {
-}
+variable "arc_controller_namespace" {}
 
-variable "arc_controller_chart_version" {
-}
+variable "arc_controller_chart_version" {}
 
-variable "arc_runner_namespace" {
-}
+variable "arc_runner_namespace" {}
 
-variable "arc_runner_chart_version" {
-}
+variable "arc_runner_chart_version" {}
 
-variable "githubConfigUrl" {
-}
-
-variable "github_token" {
-}
-
-variable "maxRunners" {
-}
-
-variable "minRunners" {
-}
-
-variable "containerModeType" {
-}
-
-variable "VolumeClaimAccessModes" {
-}
-
-variable "VolumeClaimStorageClassName" {
-}
-
-variable "VolumeClaimResourcesRequestsStorage" {
+variable "arc_runner_config" {
+  type = list(object({
+    name  = string
+    value = string
+  }))
 }

--- a/actions-ebs-chart/variables.tf
+++ b/actions-ebs-chart/variables.tf
@@ -1,5 +1,3 @@
-variable "open_ebs_namespace" {
-}
+variable "open_ebs_namespace" {}
 
-variable "ebs_chart_version" {
-}
+variable "ebs_chart_version" {}

--- a/aws/actions-cluster/outputs.tf
+++ b/aws/actions-cluster/outputs.tf
@@ -3,7 +3,7 @@ output "action_cluster_endpoint" {
 }
 
 output "action_cluster_certificate_authority_data" {
-  value = module.eks.cluster_certificate_authority_data
+  value     = module.eks.cluster_certificate_authority_data
   sensitive = true
 }
 

--- a/aws/dind/main.tf
+++ b/aws/dind/main.tf
@@ -49,12 +49,7 @@ module "actions_actions_arc_chart" {
 
   arc_runner_namespace     = var.arc_runner_namespace
   arc_runner_chart_version = var.arc_runner_chart_version
-
-  githubConfigUrl   = var.githubConfigUrl
-  github_token      = var.github_token
-  maxRunners        = var.maxRunners
-  minRunners        = var.minRunners
-  containerModeType = var.containerModeType
+  arc_runner_config        = var.arc_runner_config
 
   depends_on = [
     module.action_cluster

--- a/aws/dind/terraform.tfvars
+++ b/aws/dind/terraform.tfvars
@@ -32,9 +32,19 @@ arc_controller_chart_version = "0.7.0"
 
 arc_runner_namespace     = "arc-runners"
 arc_runner_chart_version = "0.7.0"
-
-githubConfigUrl   = "https://github.com/" # This is a dummy repo
-github_token      = "ghp_3"               # This is a dummy token
-maxRunners        = "2"
-minRunners        = "1"
-containerModeType = "dind"
+arc_runner_config = [{
+  name  = "githubConfigUrl"
+  value = "https://github.com/" # This is a dummy repo
+  }, {
+  name  = "githubConfigSecret.github_token"
+  value = "ghp_3" # This is a dummy token
+  }, {
+  name  = "maxRunners"
+  value = "3"
+  }, {
+  name  = "minRunners"
+  value = "1"
+  }, {
+  name  = "containerMode.type"
+  value = "dind"
+}]

--- a/aws/dind/variables.tf
+++ b/aws/dind/variables.tf
@@ -51,12 +51,4 @@ variable "arc_runner_namespace" {}
 
 variable "arc_runner_chart_version" {}
 
-variable "githubConfigUrl" {}
-
-variable "github_token" {}
-
-variable "maxRunners" {}
-
-variable "minRunners" {}
-
-variable "containerModeType" {}
+variable "arc_runner_config" {}

--- a/aws/dind/versions.tf
+++ b/aws/dind/versions.tf
@@ -10,8 +10,7 @@ terraform {
       source = "hashicorp/kubernetes"
     }
     kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = "1.14.0"
+      source = "gavinbunney/kubectl"
     }
   }
 }

--- a/aws/k8s/main.tf
+++ b/aws/k8s/main.tf
@@ -57,15 +57,7 @@ module "actions_actions_arc_chart" {
 
   arc_runner_namespace     = var.arc_runner_namespace
   arc_runner_chart_version = var.arc_runner_chart_version
-
-  githubConfigUrl                     = var.githubConfigUrl
-  github_token                        = var.github_token
-  maxRunners                          = var.maxRunners
-  minRunners                          = var.minRunners
-  containerModeType                   = var.containerModeType
-  VolumeClaimAccessModes              = var.VolumeClaimAccessModes
-  VolumeClaimStorageClassName         = var.VolumeClaimStorageClassName
-  VolumeClaimResourcesRequestsStorage = var.VolumeClaimResourcesRequestsStorage
+  arc_runner_config        = var.arc_runner_config
 
   depends_on = [
     module.action_cluster,

--- a/aws/k8s/terraform.tfvars
+++ b/aws/k8s/terraform.tfvars
@@ -36,12 +36,28 @@ arc_controller_chart_version = "0.7.0"
 
 arc_runner_namespace     = "arc-runners"
 arc_runner_chart_version = "0.7.0"
-
-githubConfigUrl                     = "https://github.com/" # This is a dummy repo
-github_token                        = "ghp_3"               # This is a dummy token
-maxRunners                          = "2"
-minRunners                          = "1"
-containerModeType                   = "kubernetes"
-VolumeClaimAccessModes              = "ReadWriteOnce"
-VolumeClaimStorageClassName         = "dynamic-blob-storage"
-VolumeClaimResourcesRequestsStorage = "1Gi"
+arc_runner_config = [{
+  name  = "githubConfigUrl"
+  value = "https://github.com/" # This is a dummy repo
+  }, {
+  name  = "githubConfigSecret.github_token"
+  value = "ghp_3" # This is a dummy token
+  }, {
+  name  = "maxRunners"
+  value = "3"
+  }, {
+  name  = "minRunners"
+  value = "1"
+  }, {
+  name  = "containerMode.type"
+  value = "kubernetes"
+  }, {
+  name  = "containerMode.kubernetesModeWorkVolumeClaim.accessModes[0]"
+  value = "ReadWriteOnce"
+  }, {
+  name  = "containerMode.kubernetesModeWorkVolumeClaim.storageClassName"
+  value = "openebs-hostpath"
+  }, {
+  name  = "containerMode.kubernetesModeWorkVolumeClaim.resources.requests.storage"
+  value = "1Gi"
+}]

--- a/aws/k8s/variables.tf
+++ b/aws/k8s/variables.tf
@@ -56,19 +56,5 @@ variable "arc_runner_namespace" {}
 
 variable "arc_runner_chart_version" {}
 
-variable "githubConfigUrl" {}
-
-variable "github_token" {}
-
-variable "maxRunners" {}
-
-variable "minRunners" {}
-
-variable "containerModeType" {}
-
-variable "VolumeClaimAccessModes" {}
-
-variable "VolumeClaimStorageClassName" {}
-
-variable "VolumeClaimResourcesRequestsStorage" {}
+variable "arc_runner_config" {}
 

--- a/aws/k8s/versions.tf
+++ b/aws/k8s/versions.tf
@@ -10,8 +10,7 @@ terraform {
       source = "hashicorp/kubernetes"
     }
     kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = "1.14.0"
+      source = "gavinbunney/kubectl"
     }
   }
 }

--- a/kind/actions-cluster/main.tf
+++ b/kind/actions-cluster/main.tf
@@ -1,13 +1,10 @@
 terraform {
   required_providers {
     kind = {
-      source  = "tehcyx/kind"
-      version = "0.2.1"
+      source = "tehcyx/kind"
     }
   }
 }
-
-provider "kind" {}
 
 resource "kind_cluster" "actions_local_cluster" {
   name           = var.cluster_name

--- a/kind/actions-cluster/outputs.tf
+++ b/kind/actions-cluster/outputs.tf
@@ -3,17 +3,17 @@ output "action_cluster_kubeconfig" {
 }
 
 output "action_cluster_client_certificate" {
-  value = kind_cluster.actions_local_cluster.client_certificate
+  value     = kind_cluster.actions_local_cluster.client_certificate
   sensitive = true
 }
 
 output "action_cluster_client_key" {
-  value = kind_cluster.actions_local_cluster.client_key
+  value     = kind_cluster.actions_local_cluster.client_key
   sensitive = true
 }
 
 output "action_cluster_ca_certificate" {
-  value = kind_cluster.actions_local_cluster.cluster_ca_certificate
+  value     = kind_cluster.actions_local_cluster.cluster_ca_certificate
   sensitive = true
 }
 

--- a/kind/dind/main.tf
+++ b/kind/dind/main.tf
@@ -15,12 +15,7 @@ module "actions_actions_arc_chart" {
 
   arc_runner_namespace     = var.arc_runner_namespace
   arc_runner_chart_version = var.arc_runner_chart_version
-
-  githubConfigUrl                     = var.githubConfigUrl
-  github_token                        = var.github_token
-  maxRunners                          = var.maxRunners
-  minRunners                          = var.minRunners
-  containerModeType                   = var.containerModeType
+  arc_runner_config        = var.arc_runner_config
 
   depends_on = [
     module.action_cluster

--- a/kind/dind/terraform.tfvars
+++ b/kind/dind/terraform.tfvars
@@ -10,9 +10,19 @@ arc_controller_chart_version = "0.7.0"
 
 arc_runner_namespace     = "arc-runners"
 arc_runner_chart_version = "0.7.0"
-
-githubConfigUrl                     = "https://github.com/" # This is a dummy repo
-github_token                        = "ghp_3"               # This is a dummy token
-maxRunners                          = "3"
-minRunners                          = "1"
-containerModeType                   = "dind"
+arc_runner_config = [{
+  name  = "githubConfigUrl"
+  value = "https://github.com/" # This is a dummy repo
+  }, {
+  name  = "githubConfigSecret.github_token"
+  value = "ghp_3" # This is a dummy token
+  }, {
+  name  = "maxRunners"
+  value = "3"
+  }, {
+  name  = "minRunners"
+  value = "1"
+  }, {
+  name  = "containerMode.type"
+  value = "dind"
+}]

--- a/kind/dind/variables.tf
+++ b/kind/dind/variables.tf
@@ -15,12 +15,4 @@ variable "arc_runner_namespace" {}
 
 variable "arc_runner_chart_version" {}
 
-variable "githubConfigUrl" {}
-
-variable "github_token" {}
-
-variable "maxRunners" {}
-
-variable "minRunners" {}
-
-variable "containerModeType" {}
+variable "arc_runner_config" {}

--- a/kind/k8s/main.tf
+++ b/kind/k8s/main.tf
@@ -20,15 +20,7 @@ module "actions_actions_arc_chart" {
 
   arc_runner_namespace     = var.arc_runner_namespace
   arc_runner_chart_version = var.arc_runner_chart_version
-
-  githubConfigUrl                     = var.githubConfigUrl
-  github_token                        = var.github_token
-  maxRunners                          = var.maxRunners
-  minRunners                          = var.minRunners
-  containerModeType                   = var.containerModeType
-  VolumeClaimAccessModes              = var.VolumeClaimAccessModes
-  VolumeClaimStorageClassName         = var.VolumeClaimStorageClassName
-  VolumeClaimResourcesRequestsStorage = var.VolumeClaimResourcesRequestsStorage
+  arc_runner_config        = var.arc_runner_config
 
   depends_on = [
     module.action_cluster,

--- a/kind/k8s/terraform.tfvars
+++ b/kind/k8s/terraform.tfvars
@@ -15,12 +15,28 @@ arc_controller_chart_version = "0.7.0"
 
 arc_runner_namespace     = "arc-runners"
 arc_runner_chart_version = "0.7.0"
-
-githubConfigUrl                     = "https://github.com/" # This is a dummy repo
-github_token                        = "ghp_3"               # This is a dummy token
-maxRunners                          = "3"
-minRunners                          = "1"
-containerModeType                   = "kubernetes"
-VolumeClaimAccessModes              = "ReadWriteOnce"
-VolumeClaimStorageClassName         = "openebs-hostpath"
-VolumeClaimResourcesRequestsStorage = "1Gi"
+arc_runner_config = [{
+  name  = "githubConfigUrl"
+  value = "https://github.com/" # This is a dummy repo
+  }, {
+  name  = "githubConfigSecret.github_token"
+  value = "ghp_3" # This is a dummy token
+  }, {
+  name  = "maxRunners"
+  value = "3"
+  }, {
+  name  = "minRunners"
+  value = "1"
+  }, {
+  name  = "containerMode.type"
+  value = "kubernetes"
+  }, {
+  name  = "containerMode.kubernetesModeWorkVolumeClaim.accessModes[0]"
+  value = "ReadWriteOnce"
+  }, {
+  name  = "containerMode.kubernetesModeWorkVolumeClaim.storageClassName"
+  value = "openebs-hostpath"
+  }, {
+  name  = "containerMode.kubernetesModeWorkVolumeClaim.resources.requests.storage"
+  value = "1Gi"
+}]

--- a/kind/k8s/variables.tf
+++ b/kind/k8s/variables.tf
@@ -20,18 +20,4 @@ variable "arc_runner_namespace" {}
 
 variable "arc_runner_chart_version" {}
 
-variable "githubConfigUrl" {}
-
-variable "github_token" {}
-
-variable "maxRunners" {}
-
-variable "minRunners" {}
-
-variable "containerModeType" {}
-
-variable "VolumeClaimAccessModes" {}
-
-variable "VolumeClaimStorageClassName" {}
-
-variable "VolumeClaimResourcesRequestsStorage" {}
+variable "arc_runner_config" {}

--- a/minikube/actions-cluster/outputs.tf
+++ b/minikube/actions-cluster/outputs.tf
@@ -1,15 +1,15 @@
 output "action_cluster_client_certificate" {
-  value = minikube_cluster.actions_local_cluster.client_certificate
+  value     = minikube_cluster.actions_local_cluster.client_certificate
   sensitive = true
 }
 
 output "action_cluster_client_key" {
-  value = minikube_cluster.actions_local_cluster.client_key
+  value     = minikube_cluster.actions_local_cluster.client_key
   sensitive = true
 }
 
 output "action_cluster_ca_certificate" {
-  value = minikube_cluster.actions_local_cluster.cluster_ca_certificate
+  value     = minikube_cluster.actions_local_cluster.cluster_ca_certificate
   sensitive = true
 }
 

--- a/minikube/dind/main.tf
+++ b/minikube/dind/main.tf
@@ -18,12 +18,7 @@ module "actions_actions_arc_chart" {
 
   arc_runner_namespace     = var.arc_runner_namespace
   arc_runner_chart_version = var.arc_runner_chart_version
-
-  githubConfigUrl                     = var.githubConfigUrl
-  github_token                        = var.github_token
-  maxRunners                          = var.maxRunners
-  minRunners                          = var.minRunners
-  containerModeType                   = var.containerModeType
+  arc_runner_config        = var.arc_runner_config
 
   depends_on = [
     module.action_cluster

--- a/minikube/dind/terraform.tfvars
+++ b/minikube/dind/terraform.tfvars
@@ -21,8 +21,19 @@ arc_controller_chart_version = "0.7.0"
 arc_runner_namespace     = "arc-runners"
 arc_runner_chart_version = "0.7.0"
 
-githubConfigUrl                     = "https://github.com/" # This is a dummy repo
-github_token                        = "ghp_3"               # This is a dummy token
-maxRunners                          = "3"
-minRunners                          = "1"
-containerModeType                   = "dind"
+arc_runner_config = [{
+  name  = "githubConfigUrl"
+  value = "https://github.com/" # This is a dummy repo
+  }, {
+  name  = "githubConfigSecret.github_token"
+  value = "ghp_3" # This is a dummy token
+  }, {
+  name  = "maxRunners"
+  value = "3"
+  }, {
+  name  = "minRunners"
+  value = "1"
+  }, {
+  name  = "containerMode.type"
+  value = "dind"
+}]

--- a/minikube/dind/variables.tf
+++ b/minikube/dind/variables.tf
@@ -25,12 +25,4 @@ variable "arc_runner_namespace" {}
 
 variable "arc_runner_chart_version" {}
 
-variable "githubConfigUrl" {}
-
-variable "github_token" {}
-
-variable "maxRunners" {}
-
-variable "minRunners" {}
-
-variable "containerModeType" {}
+variable "arc_runner_config" {}

--- a/minikube/k8s/main.tf
+++ b/minikube/k8s/main.tf
@@ -24,15 +24,7 @@ module "actions_actions_arc_chart" {
 
   arc_runner_namespace     = var.arc_runner_namespace
   arc_runner_chart_version = var.arc_runner_chart_version
-
-  githubConfigUrl                     = var.githubConfigUrl
-  github_token                        = var.github_token
-  maxRunners                          = var.maxRunners
-  minRunners                          = var.minRunners
-  containerModeType                   = var.containerModeType
-  VolumeClaimAccessModes              = var.VolumeClaimAccessModes
-  VolumeClaimStorageClassName         = var.VolumeClaimStorageClassName
-  VolumeClaimResourcesRequestsStorage = var.VolumeClaimResourcesRequestsStorage
+  arc_runner_config        = var.arc_runner_config
 
   depends_on = [
     module.action_cluster,

--- a/minikube/k8s/terraform.tfvars
+++ b/minikube/k8s/terraform.tfvars
@@ -24,12 +24,31 @@ arc_controller_chart_version = "0.7.0"
 
 arc_runner_namespace     = "arc-runners"
 arc_runner_chart_version = "0.7.0"
+arc_runner_config = [{
+  name  = "githubConfigUrl"
+  value = "https://github.com/" # This is a dummy repo
+  }, {
+  name  = "githubConfigSecret.github_token"
+  value = "ghp_3" # This is a dummy token
+  }, {
+  name  = "maxRunners"
+  value = "3"
+  }, {
+  name  = "minRunners"
+  value = "1"
+  }, {
+  name  = "containerMode.type"
+  value = "kubernetes"
+  }, {
+  name  = "containerMode.kubernetesModeWorkVolumeClaim.accessModes[0]"
+  value = "ReadWriteOnce"
+  }, {
+  name  = "containerMode.kubernetesModeWorkVolumeClaim.storageClassName"
+  value = "openebs-hostpath"
+  }, {
+  name  = "containerMode.kubernetesModeWorkVolumeClaim.resources.requests.storage"
+  value = "1Gi"
+}]
 
-githubConfigUrl                     = "https://github.com/" # This is a dummy repo
-github_token                        = "ghp_3"               # This is a dummy token
-maxRunners                          = "3"
-minRunners                          = "1"
-containerModeType                   = "kubernetes"
-VolumeClaimAccessModes              = "ReadWriteOnce"
-VolumeClaimStorageClassName         = "openebs-hostpath"
-VolumeClaimResourcesRequestsStorage = "1Gi"
+# githubConfigUrl                     = "https://github.com/" # This is a dummy repo
+# github_token                        = "ghp_3"               # This is a dummy token

--- a/minikube/k8s/variables.tf
+++ b/minikube/k8s/variables.tf
@@ -30,19 +30,4 @@ variable "arc_runner_namespace" {}
 
 variable "arc_runner_chart_version" {}
 
-variable "githubConfigUrl" {}
-
-variable "github_token" {}
-
-variable "maxRunners" {}
-
-variable "minRunners" {}
-
-variable "containerModeType" {}
-
-variable "VolumeClaimAccessModes" {}
-
-variable "VolumeClaimStorageClassName" {}
-
-variable "VolumeClaimResourcesRequestsStorage" {}
-
+variable "arc_runner_config" {}


### PR DESCRIPTION
- Use [Dynamic block](https://developer.hashicorp.com/terraform/language/expressions/dynamic-blocks) to set Runner configuration.
- Update Kind, Minikube and AWS configuration both on K8s and dind level to use new configuration
- Format terraform confoguration